### PR TITLE
restore call to flush()

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,15 @@ ldclient.once('ready', function() {
       console.log("Not showing your feature to " + user.key);
     }
 
-    // Close the LaunchDarkly SDK to flush all buffered events and close all open connections.
+    // Close the LaunchDarkly SDK, after ensuring that analytics events have been delivered.
     //
-    // IMPORTANT: in a real application, this step is something you would only do when the application is
-    // about to quit-- NOT after every call to variation(). The reason that this step is inside the variation
-    // handler is flags cannot be evaluated after the SDK is closed.
-    ldclient.close();
+    // IMPORTANT: in a real application, you would only call close() when the application is
+    // about to quit-- NOT after every call to variation(). The reason that this step is
+    // inside the variation handler is that we want it to happen after the SDK has been
+    // initialized and after the flag has been evaluated. Node.js will not allow the
+    // application to exit as long as the SDK is still running.
+    ldclient.flush(function() {
+      ldclient.close();
+    });
   });
 });


### PR DESCRIPTION
This reverts https://github.com/launchdarkly/hello-node-server/commit/ba761ad1c13d9656dcc44ed5a6db692f641c7102 which had mistakenly removed the `flush()` call, causing the demo app to exit immediately without having a chance to deliver its events. The same error is currently in our Quickstart pages on the website, and will be fixed ASAP.

(The most likely reason for this mistake was that in some of the other SDKs, like Java and Go, `close()` includes a synchronous flush. But in Node, things like that can't really be synchronous— such behavior has to be implemented with a callback. And since the original `close()` in earlier versions of the SDK did not include flushing events, but just immediately stopped the SDK, for backward compatibility we couldn't add a callback without breaking the guarantee that the SDK really had been stopped as soon as the method returned.)