### PR TITLE
ci: Add dependency-scan GitHub Actions workflow

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,30 @@
+name: Dependency Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate-nodejs-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Generate SBOM
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
+        with:
+          types: 'nodejs'
+
+  evaluate-policy:
+    runs-on: ubuntu-latest
+    needs:
+      - generate-nodejs-sbom
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Evaluate SBOM Policy
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
+        with:
+          artifacts-pattern: bom-*


### PR DESCRIPTION
# [SEC-7263] Add dependency-scan GitHub Actions workflow

## Summary
Adds a new GitHub Actions workflow to generate Software Bill of Materials (SBOM) for Node.js dependencies and evaluate them against LaunchDarkly's license policies. This workflow is part of security initiative SEC-7263 to implement dependency scanning across all LaunchDarkly npm ecosystem repositories.

The workflow includes two jobs:
- `generate-nodejs-sbom`: Creates SBOM using launchdarkly/gh-actions
- `evaluate-policy`: Evaluates generated SBOM against defined license policies

## Review & Testing Checklist for Human
- [ ] **Test workflow execution**: Create a test PR to verify the workflow runs successfully without errors
- [ ] **Verify SBOM generation**: Confirm the workflow generates valid SBOM artifacts for this repository's minimal dependency set (@launchdarkly/node-server-sdk)
- [ ] **Check policy evaluation**: Ensure policy evaluation doesn't block legitimate dependencies or flag false positives
- [ ] **Validate CI integration**: Confirm the new workflow doesn't interfere with existing CI processes or cause build failures

### Notes
- This workflow uses the public `launchdarkly/gh-actions` repo (appropriate for public repositories)
- Policy evaluation may detect legitimate license violations - this is expected behavior, not a bug
- Similar workflows have been implemented across ~16 other LaunchDarkly npm repositories as part of this initiative
- Requested by: @pkaeding
- Link to Devin session: https://app.devin.ai/sessions/434bb14b7bac4d81b9979b88965be92b

[SEC-7263]: https://launchdarkly.atlassian.net/browse/SEC-7263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ